### PR TITLE
Increase timeout for "the-rewarder" challenge.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "truster": "npm run compile && npx mocha --timeout 5000 --exit test/truster/truster.challenge.js",
     "naive-receiver": "npm run compile && npx mocha --timeout 5000 --exit test/naive-receiver/naive-receiver.challenge.js",
     "side-entrance": "npm run compile && npx mocha --timeout 5000 --exit test/side-entrance/side-entrance.challenge.js",
-    "the-rewarder": "npm run compile && npx mocha --timeout 5000 --exit test/the-rewarder/the-rewarder.challenge.js",
+    "the-rewarder": "npm run compile && npx mocha --timeout 15000 --exit test/the-rewarder/the-rewarder.challenge.js",
     "selfie": "npm run compile && npx mocha --timeout 5000 --exit test/selfie/selfie.challenge.js",
     "compromised": "npm run compile && npx mocha --timeout 5000 --exit test/compromised/compromised.challenge.js",
     "puppet": "npm run compile && npx mocha --timeout 5000 --exit test/puppet/puppet.challenge.js",


### PR DESCRIPTION
Even with the exploit section blank, it takes 9s to run on my setup.